### PR TITLE
Add tests for ClientProcessorForJava#processCaseModel

### DIFF
--- a/opensrp-app/src/test/java/org/smartregister/sync/ClientProcessorForJavaTest.java
+++ b/opensrp-app/src/test/java/org/smartregister/sync/ClientProcessorForJavaTest.java
@@ -553,12 +553,6 @@ public class ClientProcessorForJavaTest extends BaseUnitTest {
         Assert.assertFalse(clientProcessor.processClientClass(classificationRule, event, null));
     }
 
-    @After
-    public void tearDown() {
-        ReflectionHelpers.setStaticField(CoreLibrary.class, "instance", null);
-        clientProcessor = null;
-    }
-
     @Test
     public void processCaseModelWhenGivenColumnConfigurationFromEventObsShouldPopulateContentValuesAsPerColumnConfiguration() {
         String eventJson = "{\"baseEntityId\":\"021a1da2-cebf-44fa-9ef3-3ffc18fa6356\",\"entityType\":\"vaccination\",\"eventDate\":\"2018-10-15T20:00:00.000-04:00\",\"eventType\":\"Vaccination\",\"formSubmissionId\":\"e9c0c4ec-63c3-4104-958e-21e133efd3b2\",\"locationId\":\"2c3a0ebd-f79d-4128-a6d3-5dfbffbd01c8\",\"obs\":[{\"fieldCode\":\"1410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"date\",\"fieldType\":\"concept\",\"formSubmissionField\":\"rota_2\",\"humanReadableValues\":[],\"parentCode\":\"159698AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"2018-10-16\"]},{\"fieldCode\":\"1418AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"calculate\",\"fieldType\":\"concept\",\"formSubmissionField\":\"rota_2_dose\",\"humanReadableValues\":[],\"parentCode\":\"159698AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"2\"]}],\"providerId\":\"chwone\",\"version\":1567465052005,\"clientApplicationVersion\":1,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-10-07T05:49:52.992-04:00\",\"dateEdited\":\"2019-09-18T06:10:56.784-04:00\",\"serverVersion\":1568801628709}";
@@ -571,7 +565,7 @@ public class ClientProcessorForJavaTest extends BaseUnitTest {
 
         clientProcessor.processCaseModel(event, null, column, contentValues);
 
-        Assert.assertEquals("rota_2", contentValues.getAsString("name"));
+        assertEquals("rota_2", contentValues.getAsString("name"));
     }
 
 
@@ -587,7 +581,7 @@ public class ClientProcessorForJavaTest extends BaseUnitTest {
 
         clientProcessor.processCaseModel(event, null, column, contentValues);
 
-        Assert.assertEquals("chwone", contentValues.getAsString("anmid"));
+        assertEquals("chwone", contentValues.getAsString("anmid"));
     }
 
 
@@ -605,7 +599,7 @@ public class ClientProcessorForJavaTest extends BaseUnitTest {
 
         clientProcessor.processCaseModel(event, client, column, contentValues);
 
-        Assert.assertEquals("4602652", contentValues.getAsString("unique_id"));
+        assertEquals("4602652", contentValues.getAsString("unique_id"));
     }
 
 
@@ -623,7 +617,7 @@ public class ClientProcessorForJavaTest extends BaseUnitTest {
 
         clientProcessor.processCaseModel(event, client, column, contentValues);
 
-        Assert.assertEquals("af3e29be-88ee-4063-bb02-963a64c664ab", contentValues.getAsString("relational_id"));
+        assertEquals("af3e29be-88ee-4063-bb02-963a64c664ab", contentValues.getAsString("relational_id"));
     }
 
 
@@ -642,6 +636,12 @@ public class ClientProcessorForJavaTest extends BaseUnitTest {
         ReflectionHelpers.setStaticField(ClientProcessorForJava.class, "instance", clientProcessor);
         clientProcessor.processCaseModel(event, client, column, contentValues);
 
-        Assert.assertEquals("Kasabuni", contentValues.get("village_town"));
+        assertEquals("Kasabuni", contentValues.get("village_town"));
+    }
+
+    @After
+    public void tearDown() {
+        ReflectionHelpers.setStaticField(CoreLibrary.class, "instance", null);
+        clientProcessor = null;
     }
 }

--- a/opensrp-app/src/test/java/org/smartregister/sync/ClientProcessorForJavaTest.java
+++ b/opensrp-app/src/test/java/org/smartregister/sync/ClientProcessorForJavaTest.java
@@ -43,6 +43,7 @@ import org.smartregister.repository.DetailsRepository;
 import org.smartregister.shadows.ShadowAssetHandler;
 import org.smartregister.util.AssetHandler;
 import org.smartregister.util.DateTimeTypeConverter;
+import org.smartregister.util.JsonFormUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -556,5 +557,91 @@ public class ClientProcessorForJavaTest extends BaseUnitTest {
     public void tearDown() {
         ReflectionHelpers.setStaticField(CoreLibrary.class, "instance", null);
         clientProcessor = null;
+    }
+
+    @Test
+    public void processCaseModelWhenGivenColumnConfigurationFromEventObsShouldPopulateContentValuesAsPerColumnConfiguration() {
+        String eventJson = "{\"baseEntityId\":\"021a1da2-cebf-44fa-9ef3-3ffc18fa6356\",\"entityType\":\"vaccination\",\"eventDate\":\"2018-10-15T20:00:00.000-04:00\",\"eventType\":\"Vaccination\",\"formSubmissionId\":\"e9c0c4ec-63c3-4104-958e-21e133efd3b2\",\"locationId\":\"2c3a0ebd-f79d-4128-a6d3-5dfbffbd01c8\",\"obs\":[{\"fieldCode\":\"1410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"date\",\"fieldType\":\"concept\",\"formSubmissionField\":\"rota_2\",\"humanReadableValues\":[],\"parentCode\":\"159698AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"2018-10-16\"]},{\"fieldCode\":\"1418AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"calculate\",\"fieldType\":\"concept\",\"formSubmissionField\":\"rota_2_dose\",\"humanReadableValues\":[],\"parentCode\":\"159698AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"2\"]}],\"providerId\":\"chwone\",\"version\":1567465052005,\"clientApplicationVersion\":1,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-10-07T05:49:52.992-04:00\",\"dateEdited\":\"2019-09-18T06:10:56.784-04:00\",\"serverVersion\":1568801628709}";
+        String columnJson = "{\"column_name\":\"name\",\"json_mapping\":{\"field\":\"obs.fieldCode\",\"concept\":\"1410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"value_field\":\"formSubmissionField\"}}";
+        Event event = JsonFormUtils.gson.fromJson(eventJson, Event.class);
+
+        Column column = JsonFormUtils.gson.fromJson(columnJson, Column.class);
+        ContentValues contentValues = new ContentValues();
+        contentValues.put("base_entity_id", "021a1da2-cebf-44fa-9ef3-3ffc18fa6356");
+
+        clientProcessor.processCaseModel(event, null, column, contentValues);
+
+        Assert.assertEquals("rota_2", contentValues.getAsString("name"));
+    }
+
+
+    @Test
+    public void processCaseModelWhenGivenColumnConfigurationFromEventFieldShouldPopulateContentValues() {
+        String eventJson = "{\"baseEntityId\":\"021a1da2-cebf-44fa-9ef3-3ffc18fa6356\",\"entityType\":\"vaccination\",\"eventDate\":\"2018-10-15T20:00:00.000-04:00\",\"eventType\":\"Vaccination\",\"formSubmissionId\":\"e9c0c4ec-63c3-4104-958e-21e133efd3b2\",\"locationId\":\"2c3a0ebd-f79d-4128-a6d3-5dfbffbd01c8\",\"obs\":[{\"fieldCode\":\"1410AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"date\",\"fieldType\":\"concept\",\"formSubmissionField\":\"rota_2\",\"humanReadableValues\":[],\"parentCode\":\"159698AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"2018-10-16\"]},{\"fieldCode\":\"1418AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"calculate\",\"fieldType\":\"concept\",\"formSubmissionField\":\"rota_2_dose\",\"humanReadableValues\":[],\"parentCode\":\"159698AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"2\"]}],\"providerId\":\"chwone\",\"version\":1567465052005,\"clientApplicationVersion\":1,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-10-07T05:49:52.992-04:00\",\"dateEdited\":\"2019-09-18T06:10:56.784-04:00\",\"serverVersion\":1568801628709}";
+        String columnJson = "{\"column_name\":\"anmid\",\"json_mapping\":{\"field\":\"providerId\"}}";
+        Event event = JsonFormUtils.gson.fromJson(eventJson, Event.class);
+
+        Column column = JsonFormUtils.gson.fromJson(columnJson, Column.class);
+        ContentValues contentValues = new ContentValues();
+        contentValues.put("base_entity_id", "021a1da2-cebf-44fa-9ef3-3ffc18fa6356");
+
+        clientProcessor.processCaseModel(event, null, column, contentValues);
+
+        Assert.assertEquals("chwone", contentValues.getAsString("anmid"));
+    }
+
+
+    @Test
+    public void processCaseModelWhenGivenColumnConfigurationFromClientIdentifiersFieldShouldPopulateContentValues() {
+        String eventJson = "{\"baseEntityId\":\"3a221190-c004-4297-88bd-4b925e19098f\",\"entityType\":\"ec_family_member\",\"eventDate\":\"2019-09-23T20:00:00.000-04:00\",\"eventType\":\"Family Member Registration\",\"formSubmissionId\":\"af7143d3-33d9-4bb2-9fe5-14937b4ae92f\",\"locationId\":\"2c3a0ebd-f79d-4128-a6d3-5dfbffbd01c8\",\"obs\":[{\"fieldCode\":\"\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"surname\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"Kim\"]},{\"fieldCode\":\"\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"age_calculated\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"18.0\"]},{\"fieldCode\":\"\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"wra\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"0\"]},{\"fieldCode\":\"162558AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"disabilities\",\"humanReadableValues\":[\"No\"],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]},{\"fieldCode\":\"159635AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"phone_number\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"0723433455\"]},{\"fieldCode\":\"1542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"service_provider\",\"humanReadableValues\":[\"None\"],\"parentCode\":\"1542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"164369AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]},{\"fieldCode\":\"163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"start\",\"fieldType\":\"concept\",\"formSubmissionField\":\"start\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"2019-09-24 10:18:41\"]},{\"fieldCode\":\"163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"end\",\"fieldType\":\"concept\",\"formSubmissionField\":\"end\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"2019-09-24 10:21:34\"]},{\"fieldCode\":\"163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"phonenumber\",\"fieldType\":\"concept\",\"formSubmissionField\":\"phonenumber\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"+15555215554\"]}],\"providerId\":\"chwone\",\"version\":1569309694752,\"clientApplicationVersion\":2,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-09-24T03:44:30.108-04:00\",\"dateEdited\":\"2019-11-13T00:42:43.387-05:00\",\"serverVersion\":1573623789891}";
+        String clientJson = "{\"birthdate\":\"2001-09-23T20:00:00.000-04:00\",\"birthdateApprox\":false,\"deathdateApprox\":false,\"firstName\":\"Jonny\",\"gender\":\"Male\",\"middleName\":\"Kamau\",\"relationships\":{\"family\":[\"af3e29be-88ee-4063-bb02-963a64c664ab\"]},\"addresses\":[],\"attributes\":{\"id_avail\":\"[\\\"chk_none\\\"]\",\"Community_Leader\":\"[\\\"chk_none\\\"]\",\"Health_Insurance_Type\":\"iCHF\",\"Health_Insurance_Number\":\"123\"},\"baseEntityId\":\"3a221190-c004-4297-88bd-4b925e19098f\",\"identifiers\":{\"opensrp_id\":\"4602652\"},\"clientApplicationVersion\":2,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-09-24T03:44:30.015-04:00\",\"serverVersion\":1569311069836}";
+        String columnJson = "{\"column_name\":\"unique_id\",\"json_mapping\":{\"field\":\"identifiers.opensrp_id\"},\"type\":\"Client\"}";
+        Event event = JsonFormUtils.gson.fromJson(eventJson, Event.class);
+        Client client = JsonFormUtils.gson.fromJson(clientJson, Client.class);
+
+        Column column = JsonFormUtils.gson.fromJson(columnJson, Column.class);
+        ContentValues contentValues = new ContentValues();
+        contentValues.put("base_entity_id", "3a221190-c004-4297-88bd-4b925e19098f");
+
+        clientProcessor.processCaseModel(event, client, column, contentValues);
+
+        Assert.assertEquals("4602652", contentValues.getAsString("unique_id"));
+    }
+
+
+    @Test
+    public void processCaseModelWhenGivenColumnConfigurationFromClientRelationshipsFieldShouldPopulateContentValues() {
+        String eventJson = "{\"baseEntityId\":\"3a221190-c004-4297-88bd-4b925e19098f\",\"entityType\":\"ec_family_member\",\"eventDate\":\"2019-09-23T20:00:00.000-04:00\",\"eventType\":\"Family Member Registration\",\"formSubmissionId\":\"af7143d3-33d9-4bb2-9fe5-14937b4ae92f\",\"locationId\":\"2c3a0ebd-f79d-4128-a6d3-5dfbffbd01c8\",\"obs\":[{\"fieldCode\":\"\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"surname\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"Kim\"]},{\"fieldCode\":\"\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"age_calculated\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"18.0\"]},{\"fieldCode\":\"\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"wra\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"0\"]},{\"fieldCode\":\"162558AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"disabilities\",\"humanReadableValues\":[\"No\"],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"1066AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]},{\"fieldCode\":\"159635AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"phone_number\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"0723433455\"]},{\"fieldCode\":\"1542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"text\",\"fieldType\":\"concept\",\"formSubmissionField\":\"service_provider\",\"humanReadableValues\":[\"None\"],\"parentCode\":\"1542AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"saveObsAsArray\":false,\"values\":[\"164369AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"]},{\"fieldCode\":\"163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"start\",\"fieldType\":\"concept\",\"formSubmissionField\":\"start\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"2019-09-24 10:18:41\"]},{\"fieldCode\":\"163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"end\",\"fieldType\":\"concept\",\"formSubmissionField\":\"end\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"2019-09-24 10:21:34\"]},{\"fieldCode\":\"163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\",\"fieldDataType\":\"phonenumber\",\"fieldType\":\"concept\",\"formSubmissionField\":\"phonenumber\",\"humanReadableValues\":[],\"parentCode\":\"\",\"saveObsAsArray\":false,\"values\":[\"+15555215554\"]}],\"providerId\":\"chwone\",\"version\":1569309694752,\"clientApplicationVersion\":2,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-09-24T03:44:30.108-04:00\",\"dateEdited\":\"2019-11-13T00:42:43.387-05:00\",\"serverVersion\":1573623789891}";
+        String clientJson = "{\"birthdate\":\"2001-09-23T20:00:00.000-04:00\",\"birthdateApprox\":false,\"deathdateApprox\":false,\"firstName\":\"Jonny\",\"gender\":\"Male\",\"middleName\":\"Kamau\",\"relationships\":{\"family\":[\"af3e29be-88ee-4063-bb02-963a64c664ab\"]},\"addresses\":[],\"attributes\":{\"id_avail\":\"[\\\"chk_none\\\"]\",\"Community_Leader\":\"[\\\"chk_none\\\"]\",\"Health_Insurance_Type\":\"iCHF\",\"Health_Insurance_Number\":\"123\"},\"baseEntityId\":\"3a221190-c004-4297-88bd-4b925e19098f\",\"identifiers\":{\"opensrp_id\":\"4602652\"},\"clientApplicationVersion\":2,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-09-24T03:44:30.015-04:00\",\"serverVersion\":1569311069836}";
+        String columnJson = "{\"column_name\":\"relational_id\",\"json_mapping\":{\"field\":\"relationships.family\"},\"type\":\"Client\"}";
+        Event event = JsonFormUtils.gson.fromJson(eventJson, Event.class);
+        Client client = JsonFormUtils.gson.fromJson(clientJson, Client.class);
+
+        Column column = JsonFormUtils.gson.fromJson(columnJson, Column.class);
+        ContentValues contentValues = new ContentValues();
+        contentValues.put("base_entity_id", "3a221190-c004-4297-88bd-4b925e19098f");
+
+        clientProcessor.processCaseModel(event, client, column, contentValues);
+
+        Assert.assertEquals("af3e29be-88ee-4063-bb02-963a64c664ab", contentValues.getAsString("relational_id"));
+    }
+
+
+    @Test
+    public void processCaseModelWhenGivenColumnConfigurationFromClientAddressesFieldShouldPopulateContentValues() {
+        String eventJson = "{\"baseEntityId\":\"5b85d576-51cd-4ccc-bfd7-2b67d4af89e3\",\"entityType\":\"ec_family\",\"eventDate\":\"2019-09-24T08:12:12.000-04:00\",\"eventType\":\"Update Family Relations\",\"formSubmissionId\":\"fc673dfe-a720-405e-9b2a-0b2e4067364b\",\"locationId\":\"2c3a0ebd-f79d-4128-a6d3-5dfbffbd01c8\",\"obs\":[],\"providerId\":\"chwone\",\"version\":1569316332001,\"clientApplicationVersion\":2,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-09-24T05:13:17.700-04:00\",\"dateEdited\":\"2019-11-13T00:42:43.445-05:00\",\"serverVersion\":1573623789901}";
+        String clientJson = "{\"birthdate\":\"1970-01-01T01:00:00.000-05:00\",\"birthdateApprox\":false,\"deathdateApprox\":false,\"firstName\":\"Kitoto\",\"gender\":\"Male\",\"lastName\":\"Family\",\"relationships\":{\"family_head\":[\"9f424541-b5c6-46e5-af99-6c8d6d28559c\"],\"primary_caregiver\":[\"41b652a2-167a-4e32-9717-013b5031c972\"]},\"addresses\":[{\"addressFields\":{\"landmark\":\"Chandaria Factory\"},\"addressType\":\"\",\"cityVillage\":\"Kasabuni\"}],\"attributes\":{},\"baseEntityId\":\"5b85d576-51cd-4ccc-bfd7-2b67d4af89e3\",\"identifiers\":{\"opensrp_id\":\"4626057_family\"},\"clientApplicationVersion\":2,\"clientDatabaseVersion\":11,\"dateCreated\":\"2019-09-24T08:10:33.460-04:00\",\"dateEdited\":\"2019-09-24T05:13:17.679-04:00\",\"serverVersion\":1569316449432}";
+        String columnJson = "{\"column_name\":\"village_town\",\"json_mapping\":{\"field\":\"addresses.cityVillage\"},\"type\":\"Client\"}";
+        Event event = JsonFormUtils.gson.fromJson(eventJson, Event.class);
+        Client client = JsonFormUtils.gson.fromJson(clientJson, Client.class);
+
+        Column column = JsonFormUtils.gson.fromJson(columnJson, Column.class);
+        ContentValues contentValues = new ContentValues();
+        contentValues.put("base_entity_id", "5b85d576-51cd-4ccc-bfd7-2b67d4af89e3");
+
+        ReflectionHelpers.setStaticField(ClientProcessorForJava.class, "instance", clientProcessor);
+        clientProcessor.processCaseModel(event, client, column, contentValues);
+
+        Assert.assertEquals("Kasabuni", contentValues.get("village_town"));
     }
 }


### PR DESCRIPTION
Add tests for different branching when processing event/client using a single column mapping from the ec_client_fields mapping

**ClientProcessorForJava#processCaseModel(org.smartregister.domain.db.Event, org.smartregister.domain.db.Client, org.smartregister.domain.jsonmapping.Column, android.content.ContentValues)**