### PR TITLE
FTS search tables use client processed base Entity Id as id

### DIFF
--- a/opensrp-app/src/main/java/org/smartregister/sync/ClientProcessorForJava.java
+++ b/opensrp-app/src/main/java/org/smartregister/sync/ClientProcessorForJava.java
@@ -359,7 +359,8 @@ public class ClientProcessorForJava {
                 // save the values to db
                 executeInsertStatement(contentValues, clientType);
 
-                updateFTSsearch(clientType, baseEntityId, contentValues);
+                String entityId=contentValues.getAsString("base_entity_id");
+                updateFTSsearch(clientType, entityId, contentValues);
                 Long timestamp = getEventDate(event.getEventDate());
                 addContentValuesToDetailsTable(contentValues, timestamp);
                 updateClientDetailsTable(event, client);


### PR DESCRIPTION
- [x] FTS search tables use client processed base Entity Id as id instead of the value in event or client.

- [x] This will allow application that map `base_entity_id` to a different field to still be able to use FTS 